### PR TITLE
Added ssid_scan=1 to allow for monitoring hidden SSIDs

### DIFF
--- a/wificonfig.sh
+++ b/wificonfig.sh
@@ -24,6 +24,10 @@ if [ "$(whoami)" != "root" ]
 			wpa_cli -i wlan0 remove_network 0
 			wpa_cli -i wlan0 save
 			wpa_passphrase $ssid $wifipw >> /etc/wpa_supplicant/wpa_supplicant.conf
+			sed -i '$ d' /etc/wpa_supplicant/wpa_supplicant.conf
+			#scan_ssid=1 allows for recognizing hidden SSIDs, added spaces to keep the file uniform
+			echo "        scan_ssid=1" >> /etc/wpa_supplicant/wpa_supplicant.conf
+			echo } >> /etc/wpa_supplicant/wpa_supplicant.conf
 			wpa_cli -i wlan0 reconfigure
 		fi	
 	;;


### PR DESCRIPTION
Added the following to the wificonfig.sh file:

sed -i '$ d' /etc/wpa_supplicant/wpa_supplicant.conf
#scan_ssid=1 allows for recognizing hidden SSIDs, added spaces to keep the file uniform
echo "        scan_ssid=1" >> /etc/wpa_supplicant/wpa_supplicant.conf
echo } >> /etc/wpa_supplicant/wpa_supplicant.conf

This will remove the last line of the wpa_supplicant.conf file, add the scan_ssid1 option, and then add the closing } back to the file. This should allow the radio to look for hidden SSIDs.